### PR TITLE
release-schema.json: change lot.essentialAssets to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2023-06-13
 
-* Convert `Lot.essentialAssets` from an object to an array.
+* Change `Lot.essentialAssets` from an object to an array.
 
 ### 2023-04-05
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ In the European Union, this extension's fields correspond to [Article 4, clause 
       {
         "id": "LOT-0001",
         "hasEssentialAssets": true,
-        "essentialAssets": {
-          "description": "Significant investments have been made by the supplier in the past years and will continue to be so in the future, which will pay for themselves over a period of time well beyond the period of the contract. It includes the purchase of new vehicles, the maintenance of the modernization of the existing fleet and the renovation of the vehicle depots.",
-          "significance": "30",
-          "predominance": "40"
-        }
+        "essentialAssets": [
+          {
+            "description": "Significant investments have been made by the supplier in the past years and will continue to be so in the future, which will pay for themselves over a period of time well beyond the period of the contract. It includes the purchase of new vehicles, the maintenance of the modernization of the existing fleet and the renovation of the vehicle depots.",
+            "significance": "30",
+            "predominance": "40"
+          }
+        ]
       }
     ]
   }
@@ -50,6 +52,10 @@ In the European Union, this extension's fields correspond to [Article 4, clause 
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2023-06-13
+
+* Convert `Lot.essentialAssets` from an object to an array.
 
 ### 2023-04-05
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -5,7 +5,7 @@
         "essentialAssets": {
           "title": "Essentials assets",
           "description": "Information about the assets used for the provision of public services.",
-          "$ref": "#/definitions/EssentialAssets"
+          "$ref": "#/definitions/EssentialAsset"
         },
         "hasEssentialAssets": {
           "title": "Has essential assets",
@@ -24,7 +24,7 @@
           "type": "array",
           "description": "Information about the assets used for the provision of public services.",
           "items": {
-            "$ref": "#/definitions/EssentialAssets"
+            "$ref": "#/definitions/EssentialAsset"
           },
           "wholeListMerge": true,
           "uniqueItems": true,
@@ -40,14 +40,14 @@
         }
       }
     },
-    "EssentialAssets": {
-      "title": "Essential assets",
-      "description": "Information about the assets used for the provision of public services.",
+    "EssentialAsset": {
+      "title": "Essential asset",
+      "description": "Information about the asset used for the provision of public services.",
       "type": "object",
       "properties": {
         "description": {
           "title": "Description",
-          "description": "Description of the essential assets.",
+          "description": "Description of the essential asset.",
           "type": [
             "string",
             "null"
@@ -56,7 +56,7 @@
         },
         "significance": {
           "title": "Significance",
-          "description": "Estimated percentage share of the essential assets provided in relation to the overall assets needed for the provision of the public services.",
+          "description": "Estimated percentage share of the essential asset provided in relation to the overall asset needed for the provision of the public services.",
           "type": [
             "string",
             "null"
@@ -65,7 +65,7 @@
         },
         "predominance": {
           "title": "Predominance",
-          "description": "Estimated percentage share of assets provided compared to assets used for activities other than the public services.",
+          "description": "Estimated percentage share of asset provided compared to asset used for activities other than the public services.",
           "type": [
             "string",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -21,8 +21,14 @@
       "properties": {
         "essentialAssets": {
           "title": "Essentials assets",
+          "type": "array",
           "description": "Information about the assets used for the provision of public services.",
-          "$ref": "#/definitions/EssentialAssets"
+          "items": {
+            "$ref": "#/definitions/EssentialAssets"
+          },
+          "wholeListMerge": true,
+          "uniqueItems": true,
+          "minItems": 1
         },
         "hasEssentialAssets": {
           "title": "Has essential assets",

--- a/release-schema.json
+++ b/release-schema.json
@@ -20,7 +20,7 @@
     "Lot": {
       "properties": {
         "essentialAssets": {
-          "title": "Essentials assets",
+          "title": "Essential assets",
           "type": "array",
           "description": "Information about the assets used for the provision of public services.",
           "items": {


### PR DESCRIPTION
Realised when checking a commit to guidance.yaml that I'd forgotten to convert `essentialAssets` from an object into an array when used in `Lot`.